### PR TITLE
Noisy initializer uses random.uniform

### DIFF
--- a/scripts/experiment.py
+++ b/scripts/experiment.py
@@ -35,8 +35,8 @@ def run_experiment(
     # Define the experiment.
     challenge_sweeps = sweep("challenge_name", ["metagrating"])
     hparam_sweeps = sweep_product(
-        sweep("density_mean_value", [0.5]),
-        sweep("density_noise_stddev", [0.1]),
+        sweep("density_relative_mean", [0.5]),
+        sweep("density_noise_amplitude", [0.1]),
         sweep("beta", [2.0]),
         sweep("seed", range(3)),
         sweep("steps", [steps]),

--- a/scripts/experiment.py
+++ b/scripts/experiment.py
@@ -36,7 +36,7 @@ def run_experiment(
     challenge_sweeps = sweep("challenge_name", ["metagrating"])
     hparam_sweeps = sweep_product(
         sweep("density_relative_mean", [0.5]),
-        sweep("density_noise_amplitude", [0.1]),
+        sweep("density_relative_noise_amplitude", [0.1]),
         sweep("beta", [2.0]),
         sweep("seed", range(3)),
         sweep("steps", [steps]),

--- a/src/invrs_gym/challenges/ceviche/challenge.py
+++ b/src/invrs_gym/challenges/ceviche/challenge.py
@@ -32,7 +32,8 @@ CEVICHE_DENSITY_UPPER_BOUND = 1.0
 
 density_initializer = functools.partial(
     initializers.noisy_density_initializer,
-    relative_stddev=0.1,
+    relative_mean=0.5,
+    relative_noise_amplitude=0.1,
 )
 
 

--- a/src/invrs_gym/challenges/diffract/metagrating_challenge.py
+++ b/src/invrs_gym/challenges/diffract/metagrating_challenge.py
@@ -22,7 +22,8 @@ MIN_EFFICIENCY = "min_efficiency"
 
 density_initializer = functools.partial(
     initializers.noisy_density_initializer,
-    relative_stddev=0.1,
+    relative_mean=0.5,
+    relative_noise_amplitude=0.1,
 )
 
 

--- a/src/invrs_gym/challenges/diffract/splitter_challenge.py
+++ b/src/invrs_gym/challenges/diffract/splitter_challenge.py
@@ -35,7 +35,8 @@ UNIFORMITY_ERROR_WITHOUT_ZEROTH_ORDER = "uniformity_error_without_zeroth_order"
 
 density_initializer = functools.partial(
     initializers.noisy_density_initializer,
-    relative_stddev=0.1,
+    relative_mean=0.5,
+    relative_noise_amplitude=0.1,
 )
 
 

--- a/src/invrs_gym/challenges/extractor/challenge.py
+++ b/src/invrs_gym/challenges/extractor/challenge.py
@@ -25,7 +25,8 @@ ENHANCEMENT_DOS_MEAN = "enhancement_dos_mean"
 
 density_initializer = functools.partial(
     initializers.noisy_density_initializer,
-    relative_stddev=0.1,
+    relative_mean=0.5,
+    relative_noise_amplitude=0.1,
 )
 
 

--- a/src/invrs_gym/utils/initializers.py
+++ b/src/invrs_gym/utils/initializers.py
@@ -35,7 +35,7 @@ def noisy_density_initializer(
         seed_density: The density used to provide metadata.
         relative_mean: The relative mean value of the output density. For a value of
             `0.5`, the mean is between the density upper and lower bounds.
-        relatie_noise_amplitude: The relative amplitude of noise added to the mean.
+        relative_noise_amplitude: The relative amplitude of noise added to the mean.
         resize_method: The method used to resize a low-resolution array to the final
             array, ensuring the length scale of added noise.
 

--- a/src/invrs_gym/utils/initializers.py
+++ b/src/invrs_gym/utils/initializers.py
@@ -32,8 +32,10 @@ def noisy_density_initializer(
 
     Args:
         key: Key used in the generation of random noise.
-        density: The density to which noise is added.
-        relative_stddev: The relative standard deviation of added noise.
+        seed_density: The density used to provide metadata.
+        relative_mean: The relative mean value of the output density. For a value of
+            `0.5`, the mean is between the density upper and lower bounds.
+        relatie_noise_amplitude: The relative amplitude of noise added to the mean.
         resize_method: The method used to resize a low-resolution array to the final
             array, ensuring the length scale of added noise.
 


### PR DESCRIPTION
Rather than random normal noise, here we use random uniform noise. This eliminates the potential for outlier values skewing the results of an optimization.