### PR TITLE
Explicitly cast dimensionless quantities as int

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.2.0"
+current_version = "v0.2.1"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # invrs-gym - A collection of inverse design challenges
-`v0.2.0`
+`v0.2.1`
 
 ## Overview
 The `invrs_gym` package is an open-source gym containing a diverse set of photonic design challenges, which are relevant for a wide range of applications such as AR/VR, optical networking, LIDAR, and others.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "invrs_gym"
-version = "v0.2.0"
+version = "v0.2.1"
 description = "A collection of inverse design challenges"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/invrs_gym/__init__.py
+++ b/src/invrs_gym/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.2.0"
+__version__ = "v0.2.1"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 from invrs_gym import challenges as challenges

--- a/src/invrs_gym/challenges/ceviche/defaults.py
+++ b/src/invrs_gym/challenges/ceviche/defaults.py
@@ -226,19 +226,19 @@ def _make_wdm_spec(
     """
 
     design_extent_i, design_extent_j = design_extent_ij
-    design_extent_i_nm: int = u.resolve(design_extent_i, 1 * u.nm)
-    design_extent_j_nm: int = u.resolve(design_extent_j, 1 * u.nm)
+    design_extent_i_nm: int = int(u.resolve(design_extent_i, 1 * u.nm))
+    design_extent_j_nm: int = int(u.resolve(design_extent_j, 1 * u.nm))
 
-    wg_width_nm: int = u.resolve(WG_WIDTH, 1 * u.nm)
-    wg_length_nm: int = u.resolve(WG_LENGTH, 1 * u.nm)
+    wg_width_nm: int = int(u.resolve(WG_WIDTH, 1 * u.nm))
+    wg_length_nm: int = int(u.resolve(WG_LENGTH, 1 * u.nm))
 
-    pad_width_nm: int = u.resolve(PADDING, 1 * u.nm)
-    pml_width_nm: int = u.resolve(
-        PML_WIDTH_GRIDPOINTS * intended_sim_resolution, 1 * u.nm
+    pad_width_nm: int = int(u.resolve(PADDING, 1 * u.nm))
+    pml_width_nm: int = int(
+        u.resolve(PML_WIDTH_GRIDPOINTS * intended_sim_resolution, 1 * u.nm)
     )
 
-    extent_i_nm: int = design_extent_i_nm + 2 * wg_length_nm + 2 * pml_width_nm
-    extent_j_nm: int = design_extent_j_nm + 2 * pad_width_nm + 2 * pml_width_nm
+    extent_i_nm: int = int(design_extent_i_nm + 2 * wg_length_nm + 2 * pml_width_nm)
+    extent_j_nm: int = int(design_extent_j_nm + 2 * pad_width_nm + 2 * pml_width_nm)
 
     return wdm.spec.WdmSpec(
         extent_ij=u.Array([extent_i_nm, extent_j_nm], u.nm),


### PR DESCRIPTION
Importing `ceviche.defaults` module in a colab notebook causes a failure not reproduced locally. This is fixed by explicitly casting dimensionless quantities as ints.