### PR TITLE
Rescale density

### DIFF
--- a/src/invrs_gym/challenges/diffract/metagrating_challenge.py
+++ b/src/invrs_gym/challenges/diffract/metagrating_challenge.py
@@ -95,7 +95,7 @@ class MetagratingComponent(base.Component):
         if wavelength is None:
             wavelength = self.sim_params.wavelength
         transmission_efficiency, reflection_efficiency = common.grating_efficiency(
-            density_array=params.array,  # type: ignore[arg-type]
+            density=params,
             spec=self.spec,
             wavelength=jnp.asarray(wavelength),
             polarization=self.sim_params.polarization,

--- a/src/invrs_gym/challenges/diffract/splitter_challenge.py
+++ b/src/invrs_gym/challenges/diffract/splitter_challenge.py
@@ -14,9 +14,9 @@ from fmmax import basis, fmm  # type: ignore[import-untyped]
 from jax import tree_util
 from totypes import types
 
+from invrs_gym import utils
 from invrs_gym.challenges import base
 from invrs_gym.challenges.diffract import common
-from invrs_gym.utils import initializers
 
 Params = Dict[str, types.BoundedArray | types.Density2DArray]
 ThicknessInitializer = Callable[[jax.Array, types.BoundedArray], types.BoundedArray]
@@ -34,7 +34,7 @@ UNIFORMITY_ERROR = "uniformity_error"
 UNIFORMITY_ERROR_WITHOUT_ZEROTH_ORDER = "uniformity_error_without_zeroth_order"
 
 density_initializer = functools.partial(
-    initializers.noisy_density_initializer,
+    utils.initializers.noisy_density_initializer,
     relative_mean=0.5,
     relative_noise_amplitude=0.1,
 )
@@ -127,7 +127,7 @@ class DiffractiveSplitterComponent(base.Component):
             thickness_grating=jnp.asarray(params[THICKNESS].array),
         )
         transmission_efficiency, reflection_efficiency = common.grating_efficiency(
-            density_array=params[DENSITY].array,  # type: ignore[arg-type]
+            density=params[DENSITY],  # type: ignore[arg-type]
             spec=spec,
             wavelength=jnp.asarray(wavelength),
             polarization=self.sim_params.polarization,
@@ -327,7 +327,9 @@ NORMALIZED_EFFICIENCY_UPPER_BOUND = 1.3
 def diffractive_splitter(
     minimum_width: int = 10,
     minimum_spacing: int = 10,
-    thickness_initializer: ThicknessInitializer = initializers.identity_initializer,
+    thickness_initializer: ThicknessInitializer = (
+        utils.initializers.identity_initializer
+    ),
     density_initializer: base.DensityInitializer = density_initializer,
     splitting: Tuple[int, int] = SPLITTING,
     normalized_efficiency_lower_bound: float = NORMALIZED_EFFICIENCY_LOWER_BOUND,

--- a/src/invrs_gym/challenges/extractor/component.py
+++ b/src/invrs_gym/challenges/extractor/component.py
@@ -311,7 +311,7 @@ def simulate_extractor(
     """Simulates the photon extractor device.
 
     Args:
-        density_array: Defines the pattern of the photon extractor layer.
+        density: Defines the pattern of the photon extractor layer.
         spec: Defines the physical specifcation of the photon extractor.
         layer_znum: The number of gridpoints in the z-direction used for fields.
         wavelength: The wavelength of the excitation.

--- a/src/invrs_gym/challenges/extractor/component.py
+++ b/src/invrs_gym/challenges/extractor/component.py
@@ -9,18 +9,11 @@ from typing import Any, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
-from fmmax import (  # type: ignore[import]
-    basis,
-    fields,
-    fmm,
-    pml,
-    scattering,
-    sources,
-    utils,
-)
+from fmmax import basis, fields, fmm, pml, scattering, sources  # type: ignore[import]
 from jax import tree_util
 from totypes import types
 
+from invrs_gym import utils
 from invrs_gym.challenges import base
 
 DENSITY_LOWER_BOUND = 0.0
@@ -233,7 +226,7 @@ class ExtractorComponent(base.Component):
             wavelength = self.sim_params.wavelength
 
         return simulate_extractor(
-            density_array=params.array,  # type: ignore[arg-type]
+            density=params,  # type: ignore[arg-type]
             spec=self.spec,
             layer_znum=self.layer_znum,
             wavelength=jnp.asarray(wavelength),
@@ -307,7 +300,7 @@ def seed_density(
 
 
 def simulate_extractor(
-    density_array: jnp.ndarray,
+    density: types.Density2DArray,
     spec: ExtractorSpec,
     layer_znum: Tuple[int, int, int, int, int],
     wavelength: jnp.ndarray,
@@ -330,6 +323,11 @@ def simulate_extractor(
     Returns:
         The `ExtractorResponse` and `aux` dictionary.
     """
+    density_array = utils.transforms.rescaled_density_array(
+        density,
+        lower_bound=DENSITY_LOWER_BOUND,
+        upper_bound=DENSITY_UPPER_BOUND,
+    )
     in_plane_wavevector = jnp.zeros((2,))
     primitive_lattice_vectors = basis.LatticeVectors(
         u=spec.pitch * basis.X,
@@ -361,14 +359,14 @@ def simulate_extractor(
             permittivity=jnp.full(grid_shape, spec.permittivity_ambient)
         )
         solve_result_oxide = eigensolve_pml(
-            permittivity=utils.interpolate_permittivity(
+            permittivity=utils.transforms.interpolate_permittivity(
                 permittivity_solid=jnp.asarray(spec.permittivity_oxide),
                 permittivity_void=jnp.asarray(spec.permittivity_ambient),
                 density=density_array,
             ),
         )
         solve_result_extractor = eigensolve_pml(
-            permittivity=utils.interpolate_permittivity(
+            permittivity=utils.transforms.interpolate_permittivity(
                 permittivity_solid=jnp.asarray(spec.permittivity_extractor),
                 permittivity_void=jnp.asarray(spec.permittivity_ambient),
                 density=density_array,

--- a/src/invrs_gym/challenges/sorter/polarization_challenge.py
+++ b/src/invrs_gym/challenges/sorter/polarization_challenge.py
@@ -11,9 +11,9 @@ from jax import nn
 from jax import numpy as jnp
 from totypes import types
 
+from invrs_gym import utils
 from invrs_gym.challenges import base
 from invrs_gym.challenges.sorter import common
-from invrs_gym.utils import initializers
 
 POLARIZATION_RATIO_MIN = "polarization_ratio_min"
 POLARIZATION_RATIO_MEAN = "polarization_ratio_mean"
@@ -22,7 +22,7 @@ EFFICIENCY_MEAN = "efficiency_mean"
 
 
 density_initializer = functools.partial(
-    initializers.noisy_density_initializer,
+    utils.initializers.noisy_density_initializer,
     relative_mean=0.5,
     relative_noise_amplitude=0.1,
 )
@@ -163,7 +163,7 @@ def polarization_sorter(
     minimum_width: int = MINIMUM_WIDTH,
     minimum_spacing: int = MINIMUM_SPACING,
     thickness_initializer: common.ThicknessInitializer = (
-        initializers.identity_initializer
+        utils.initializers.identity_initializer
     ),
     density_initializer: base.DensityInitializer = density_initializer,
     efficiency_target: float = EFFICIENCY_TARGET,

--- a/src/invrs_gym/utils/__init__.py
+++ b/src/invrs_gym/utils/__init__.py
@@ -1,1 +1,2 @@
 from invrs_gym.utils import initializers as initializers
+from invrs_gym.utils import transforms as transforms

--- a/src/invrs_gym/utils/transforms.py
+++ b/src/invrs_gym/utils/transforms.py
@@ -1,0 +1,47 @@
+"""Defines various transformation functions.
+
+Copyright (c) 2023 The INVRS-IO authors.
+"""
+
+from jax import numpy as jnp
+from totypes import types
+
+
+def rescaled_density_array(
+    density: types.Density2DArray,
+    lower_bound: float,
+    upper_bound: float,
+) -> jnp.ndarray:
+    """Return a density array for specified lower and upper bounds."""
+    array = density.array - density.lower_bound
+    array /= density.upper_bound - density.lower_bound
+    array *= upper_bound - lower_bound
+    return jnp.asarray(array + lower_bound)
+
+
+def interpolate_permittivity(
+    permittivity_solid: jnp.ndarray,
+    permittivity_void: jnp.ndarray,
+    density: jnp.ndarray,
+) -> jnp.ndarray:
+    """Interpolates the permittivity with a scheme that avoids zero crossings.
+
+    The interpolation uses the scheme introduced in [2019 Christiansen], which avoids
+    zero crossings that can occur with metals or lossy materials having a negative
+    real component of the permittivity. https://doi.org/10.1016/j.cma.2018.08.034
+
+    Args:
+        permittivity_solid: The permittivity of solid regions.
+        permittivity_void: The permittivity of void regions.
+        density: The density, specifying which locations are solid and which are void.
+
+    Returns:
+        The interpolated permittivity.
+    """
+    n_solid = jnp.real(jnp.sqrt(permittivity_solid))
+    k_solid = jnp.imag(jnp.sqrt(permittivity_solid))
+    n_void = jnp.real(jnp.sqrt(permittivity_void))
+    k_void = jnp.imag(jnp.sqrt(permittivity_void))
+    n = density * n_solid + (1 - density) * n_void
+    k = density * k_solid + (1 - density) * k_void
+    return (n + 1j * k) ** 2

--- a/tests/utils/test_transforms.py
+++ b/tests/utils/test_transforms.py
@@ -25,7 +25,7 @@ class InterpolateTest(unittest.TestCase):
     )
     def test_interpolated_matches_expected(self, p_solid, p_void, density, expected):
         result = transforms.interpolate_permittivity(p_solid, p_void, density)
-        onp.testing.assert_allclose(result, expected)
+        onp.testing.assert_allclose(result, expected, rtol=1e-6)
 
 
 class RescaledDensityTest(unittest.TestCase):

--- a/tests/utils/test_transforms.py
+++ b/tests/utils/test_transforms.py
@@ -1,0 +1,60 @@
+"""Tests for `utils.transforms`.
+
+Copyright (c) 2023 The INVRS-IO authors.
+"""
+
+import unittest
+
+import numpy as onp
+from parameterized import parameterized
+from totypes import types
+
+from invrs_gym.utils import transforms
+
+
+class InterpolateTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (4.0, 2.0, 0.0, 2.0),
+            (4.0, 2.0, 1.0, 4.0),
+            (4.0, 2.0, 0.5, (onp.sqrt(2) * 0.5 + onp.sqrt(4) * 0.5) ** 2),
+            (4.0 + 1.0j, 2.0, 0.0, 2.0),
+            (4.0 + 1.0j, 2.0, 1.0, 4.0 + 1.0j),
+            (4.0 + 1.0j, 2.0, 0.5, (onp.sqrt(2) * 0.5 + onp.sqrt(4 + 1.0j) * 0.5) ** 2),
+        ]
+    )
+    def test_interpolated_matches_expected(self, p_solid, p_void, density, expected):
+        result = transforms.interpolate_permittivity(p_solid, p_void, density)
+        onp.testing.assert_allclose(result, expected)
+
+
+class RescaledDensityTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            [
+                types.Density2DArray(
+                    array=onp.asarray([[0.0, 1.0, 2.0]]),
+                    lower_bound=0,
+                    upper_bound=1,
+                ),
+                0.0,  # lower bound
+                2.0,  # upper bound
+                onp.asarray([[0.0, 2.0, 4.0]]),
+            ],
+            [
+                types.Density2DArray(
+                    array=onp.asarray([[0.0, 1.0, 2.0]]),
+                    lower_bound=0,
+                    upper_bound=1,
+                ),
+                -1.0,  # lower bound
+                1.0,  # upper bound
+                onp.asarray([[-1.0, 1.0, 3.0]]),
+            ],
+        ]
+    )
+    def test_rescaled_density(self, density, lower_bound, upper_bound, expected):
+        onp.testing.assert_array_equal(
+            transforms.rescaled_density_array(density, lower_bound, upper_bound),
+            expected,
+        )


### PR DESCRIPTION
Following the recent polarization sorter challenge, here we add density rescaling to each of the challenges. This allows the optimization variable to rescaled, which may be needed if e.g. gradients with respect to different variables have significantly different magnitudes.