### PR TITLE
Log additional quantities in experiment

### DIFF
--- a/src/invrs_gym/challenges/diffract/common.py
+++ b/src/invrs_gym/challenges/diffract/common.py
@@ -10,7 +10,7 @@ import jax.numpy as jnp
 import numpy as onp
 from fmmax import basis, fields, fmm, scattering  # type: ignore[import-untyped]
 from jax import tree_util
-from totypes import types
+from totypes import json_utils, types
 
 from invrs_gym import utils
 
@@ -88,6 +88,8 @@ class GratingResponse:
     reflection_efficiency: jnp.ndarray
     expansion: basis.Expansion
 
+
+json_utils.register_custom_type(GratingResponse)
 
 tree_util.register_pytree_node(
     GratingResponse,

--- a/src/invrs_gym/challenges/extractor/component.py
+++ b/src/invrs_gym/challenges/extractor/component.py
@@ -11,7 +11,7 @@ import jax
 import jax.numpy as jnp
 from fmmax import basis, fields, fmm, pml, scattering, sources  # type: ignore[import]
 from jax import tree_util
-from totypes import types
+from totypes import json_utils, types
 
 from invrs_gym import utils
 from invrs_gym.challenges import base
@@ -119,6 +119,8 @@ class ExtractorResponse:
     extracted_power: jnp.ndarray
     collected_power: jnp.ndarray
 
+
+json_utils.register_custom_type(ExtractorResponse)
 
 tree_util.register_pytree_node(
     ExtractorResponse,

--- a/src/invrs_gym/challenges/sorter/common.py
+++ b/src/invrs_gym/challenges/sorter/common.py
@@ -10,7 +10,7 @@ import jax
 import jax.numpy as jnp
 from fmmax import basis, fields, fmm, scattering  # type: ignore[import-untyped]
 from jax import tree_util
-from totypes import types
+from totypes import json_utils, types
 
 from invrs_gym import utils
 from invrs_gym.challenges import base
@@ -110,6 +110,8 @@ class SorterResponse:
     transmission: jnp.ndarray
     reflection: jnp.ndarray
 
+
+json_utils.register_custom_type(SorterResponse)
 
 tree_util.register_pytree_node(
     SorterResponse,

--- a/tests/challenges/test_serialize.py
+++ b/tests/challenges/test_serialize.py
@@ -8,7 +8,6 @@ import unittest
 import jax
 import jax.numpy as jnp
 import numpy as onp
-import pytest
 from parameterized import parameterized
 from totypes import json_utils
 
@@ -23,10 +22,8 @@ IGNORED_CHALLENGES = (
     "ceviche_wdm",
 )
 CHALLENGE_NAMES = [
-    name
-    for name in challenges.BY_NAME.keys()
-    if name not in IGNORED_CHALLENGES
-]    
+    name for name in challenges.BY_NAME.keys() if name not in IGNORED_CHALLENGES
+]
 
 
 class TestSerialize(unittest.TestCase):

--- a/tests/challenges/test_serialize.py
+++ b/tests/challenges/test_serialize.py
@@ -1,0 +1,55 @@
+"""Tests that challenge-related quantities are serializable.
+
+Copyright (c) 2023 The INVRS-IO authors.
+"""
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as onp
+import pytest
+from parameterized import parameterized
+from totypes import json_utils
+
+from invrs_gym import challenges
+
+# Ignore expensive challenges which have lightweight counterparts for which the testing
+# below suffices to establish serializability of response, metrics, etc.
+IGNORED_CHALLENGES = (
+    "ceviche_beam_splitter",
+    "ceviche_mode_converter",
+    "ceviche_waveguide_bend",
+    "ceviche_wdm",
+)
+CHALLENGE_NAMES = [
+    name
+    for name in challenges.BY_NAME.keys()
+    if name not in IGNORED_CHALLENGES
+]    
+
+
+class TestSerialize(unittest.TestCase):
+    @parameterized.expand(CHALLENGE_NAMES)
+    def test_can_serialize(self, challenge_name):
+        challenge = challenges.BY_NAME[challenge_name]()
+        params = challenge.component.init(jax.random.PRNGKey(0))
+        response, aux = challenge.component.response(params)
+        loss = challenge.loss(response)
+        metrics = challenge.metrics(response, params, aux)
+        distance = challenge.distance_to_target(response)
+        original = {
+            "params": params,
+            "loss": loss,
+            "distance": distance,
+            "metrics": metrics,
+            "aux": aux,
+            "response": response,
+        }
+        serialized = json_utils.json_from_pytree(original)
+        restored = json_utils.pytree_from_json(serialized)
+        for key in original.keys():
+            if isinstance(original[key], jnp.ndarray):
+                self.assertIsInstance(restored[key], onp.ndarray)
+            else:
+                self.assertEqual(type(original[key]), type(restored[key]))


### PR DESCRIPTION
Log "champion" results, along with the underlying response, metrics, and auxiliary quantities in the `experiment.py` script. Add printing that to diagnose the state of an experiment.

Register the response of various components, so that they can be serialized by `totypes.json_utils`.

Add a test to ensure that all challenges are serializable.