### PR TITLE
Update loss functions

### DIFF
--- a/src/invrs_gym/challenges/ceviche/challenge.py
+++ b/src/invrs_gym/challenges/ceviche/challenge.py
@@ -114,7 +114,7 @@ class CevicheComponent(base.Component):
         response = CevicheResponse(
             s_parameters=sparams,
             wavelengths_nm=wavelengths_nm,
-            excite_port_idxs=excite_port_idxs,
+            excite_port_idxs=jnp.asarray(excite_port_idxs),
         )
         aux = {SPARAMS: sparams, FIELDS: fields}
         return response, aux

--- a/src/invrs_gym/challenges/ceviche/challenge.py
+++ b/src/invrs_gym/challenges/ceviche/challenge.py
@@ -15,7 +15,7 @@ import jax.numpy as jnp
 import numpy as onp
 from ceviche_challenges import units as u  # type: ignore[import-untyped]
 from jax import tree_util
-from totypes import types
+from totypes import json_utils, types
 
 from invrs_gym import utils
 from invrs_gym.challenges import base
@@ -78,8 +78,11 @@ class CevicheComponent(base.Component):
         excite_port_idxs: Sequence[int] = (0,),
         wavelengths_nm: Optional[jnp.ndarray] = None,
         max_parallelizm: Optional[int] = None,
-    ) -> Tuple[jnp.ndarray, base.AuxDict]:
+    ) -> Tuple["CevicheResponse", base.AuxDict]:
         """Compute the response of the component and auxilliary quantities."""
+
+        if wavelengths_nm is None:
+            wavelengths_nm = jnp.asarray(self.ceviche_model.output_wavelengths)
 
         # The ceviche simulation function is autograd-differentiable. Wrap it so that
         # it can be differentiated using jax.
@@ -92,7 +95,7 @@ class CevicheComponent(base.Component):
         def sim_fn(
             design_variable: jnp.ndarray,
             excite_port_idxs: Sequence[int],
-            wavelengths_nm: Optional[jnp.ndarray],
+            wavelengths_nm: jnp.ndarray,
             max_parallelizm: Optional[int],
         ) -> Tuple[jnp.ndarray, onp.ndarray[Any, Any]]:
             s_params, fields = self.ceviche_model.simulate(
@@ -108,7 +111,32 @@ class CevicheComponent(base.Component):
         sparams, fields = sim_fn(
             density_array, excite_port_idxs, wavelengths_nm, max_parallelizm
         )
-        return sparams, {SPARAMS: sparams, FIELDS: fields}
+        response = CevicheResponse(
+            s_parameters=sparams,
+            wavelengths_nm=wavelengths_nm,
+            excite_port_idxs=excite_port_idxs,
+        )
+        aux = {SPARAMS: sparams, FIELDS: fields}
+        return response, aux
+
+
+@dataclasses.dataclass
+class CevicheResponse:
+    """Stores the response of a Ceviche component."""
+
+    s_parameters: jnp.ndarray
+    wavelengths_nm: jnp.ndarray
+    excite_port_idxs: jnp.ndarray
+
+
+tree_util.register_pytree_node(
+    CevicheResponse,
+    flatten_func=lambda r: ((r.s_parameters,), (r.wavelengths_nm, r.excite_port_idxs)),
+    unflatten_func=lambda aux, children: CevicheResponse(*children, *aux),
+)
+
+
+json_utils.register_custom_type(CevicheResponse)
 
 
 def _seed_density(ceviche_model: defaults.Model, **kwargs: Any) -> types.Density2DArray:
@@ -223,37 +251,44 @@ class CevicheChallenge(base.Challenge):
     transmission_lower_bound: jnp.ndarray
     transmission_upper_bound: jnp.ndarray
 
-    def loss(self, response: jnp.ndarray) -> jnp.ndarray:
+    def loss(self, response: CevicheResponse) -> jnp.ndarray:
         """Compute a scalar loss from the component `response`."""
         # Power transmission is the squared magnitude of the scattering parameters.
-        transmission = jnp.abs(response) ** 2
+        transmission = jnp.abs(response.s_parameters) ** 2
+        expected_shape = (
+            len(response.wavelengths_nm),
+            len(response.excite_port_idxs),
+            len(self.component.ceviche_model.ports),
+        )
+        assert transmission.shape == expected_shape
         # Repeat the bounds to match the transmission shape. Each value in the bounds
         # is then interpreted as the bounds for a wavelength band.
         lb = _wavelength_bound(self.transmission_lower_bound, transmission.shape)
         ub = _wavelength_bound(self.transmission_upper_bound, transmission.shape)
-        return transmission_loss.orthotope_smooth_transmission_loss(
+        loss = transmission_loss.orthotope_smooth_transmission_loss(
             transmission=transmission,
             window_lower_bound=lb,
             window_upper_bound=ub,
             transmission_exponent=jnp.asarray(TRANSMISSION_EXPONENT),
             scalar_exponent=jnp.asarray(SCALAR_EXPONENT),
+            axis=(1, 2),  # Generate a per-wavelength loss
         )
+        return jnp.mean(loss)
 
-    def distance_to_target(self, response: jnp.ndarray) -> jnp.ndarray:
+    def distance_to_target(self, response: CevicheResponse) -> jnp.ndarray:
         """Compute distance from the component `response` to the challenge target."""
-        transmission = jnp.abs(response) ** 2
+        transmission = jnp.abs(response.s_parameters) ** 2
         lb = _wavelength_bound(self.transmission_lower_bound, transmission.shape)
         ub = _wavelength_bound(self.transmission_upper_bound, transmission.shape)
-        distance = transmission_loss.distance_to_window(
+        return transmission_loss.distance_to_window(
             transmission=transmission,
             window_lower_bound=lb,
             window_upper_bound=ub,
         )
-        return distance
 
     def metrics(
         self,
-        response: jnp.ndarray,
+        response: CevicheResponse,
         params: types.Density2DArray,
         aux: base.AuxDict,
     ) -> base.AuxDict:

--- a/src/invrs_gym/challenges/diffract/metagrating_challenge.py
+++ b/src/invrs_gym/challenges/diffract/metagrating_challenge.py
@@ -9,9 +9,8 @@ from typing import Any, Optional, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
-from jax import nn
 from fmmax import basis, fmm  # type: ignore[import-untyped]
-from jax import tree_util
+from jax import nn, tree_util
 from totypes import symmetry, types
 
 from invrs_gym.challenges import base

--- a/src/invrs_gym/challenges/diffract/splitter_challenge.py
+++ b/src/invrs_gym/challenges/diffract/splitter_challenge.py
@@ -330,7 +330,7 @@ DIFFRACTIVE_SPLITTER_SIM_PARAMS = common.GratingSimParams(
 )
 
 # Objective is to split into a 7 x 7 array of beams. The minimum efficiency of any
-# beam shhould be `0.7 / (7 * 7)`, while the maximum should be `1.3 / (7 * 7)`.
+# beam should be `0.7 / (7 * 7)`, while the maximum should be `1.3 / (7 * 7)`.
 SPLITTING = (7, 7)
 NORMALIZED_EFFICIENCY_LOWER_BOUND = 0.7
 NORMALIZED_EFFICIENCY_UPPER_BOUND = 1.3

--- a/src/invrs_gym/challenges/diffract/splitter_challenge.py
+++ b/src/invrs_gym/challenges/diffract/splitter_challenge.py
@@ -188,8 +188,8 @@ class DiffractiveSplitterChallenge(base.Challenge):
             transmission=efficiency,
             window_lower_bound=jnp.full(efficiency.shape, lower_bound),
             window_upper_bound=jnp.full(efficiency.shape, upper_bound),
-            transmission_exponent=TRANSMISSION_EXPONENT,
-            scalar_exponent=SCALAR_EXPONENT,
+            transmission_exponent=jnp.asarray(TRANSMISSION_EXPONENT),
+            scalar_exponent=jnp.asarray(SCALAR_EXPONENT),
             axis=(-3, -2, -1),
         )
         return jnp.mean(loss)  # Mean reduction across wavelengths, if they exist.

--- a/src/invrs_gym/loss/transmission_loss.py
+++ b/src/invrs_gym/loss/transmission_loss.py
@@ -60,8 +60,9 @@ def orthotope_smooth_transmission_loss(
     transformed_elementwise_signed_distance = jax.nn.softplus(
         elementwise_signed_psuedodistance
     )
+
     loss: jnp.ndarray = (
-        jnp.linalg.norm(transformed_elementwise_signed_distance, axis=axis)
+        _l2_norm(transformed_elementwise_signed_distance, axis=axis)
         ** scalar_exponent
     )
     return loss
@@ -149,3 +150,16 @@ def elementwise_signed_psuedodistance_to_window(
         elementwise_signed_distance_to_lower_bound,
         elementwise_signed_distance_to_upper_bound,
     )
+
+
+def _l2_norm(x: jnp.ndarray, axis: Optional[int | Sequence[int]]) -> jnp.ndarray:
+    """Compute the L2-norm for the specified axes."""
+    if axis is None:
+        axis = tuple(range(x.ndim))
+    elif isinstance(axis, int):
+        axis = (axis,)
+
+    x = jnp.moveaxis(x, axis, tuple(range(len(axis))))
+    x = x.reshape((-1,) + x.shape[len(axis):])
+    return jnp.linalg.norm(x, axis=0)
+    

--- a/src/invrs_gym/loss/transmission_loss.py
+++ b/src/invrs_gym/loss/transmission_loss.py
@@ -62,8 +62,7 @@ def orthotope_smooth_transmission_loss(
     )
 
     loss: jnp.ndarray = (
-        _l2_norm(transformed_elementwise_signed_distance, axis=axis)
-        ** scalar_exponent
+        _l2_norm(transformed_elementwise_signed_distance, axis=axis) ** scalar_exponent
     )
     return loss
 
@@ -160,6 +159,5 @@ def _l2_norm(x: jnp.ndarray, axis: Optional[int | Sequence[int]]) -> jnp.ndarray
         axis = (axis,)
 
     x = jnp.moveaxis(x, axis, tuple(range(len(axis))))
-    x = x.reshape((-1,) + x.shape[len(axis):])
+    x = x.reshape((-1,) + x.shape[len(axis) :])
     return jnp.linalg.norm(x, axis=0)
-    

--- a/src/invrs_gym/loss/transmission_loss.py
+++ b/src/invrs_gym/loss/transmission_loss.py
@@ -3,6 +3,8 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
+from typing import Optional, Sequence
+
 import jax
 import jax.numpy as jnp
 
@@ -16,6 +18,7 @@ def orthotope_smooth_transmission_loss(
     window_upper_bound: jnp.ndarray,
     transmission_exponent: jnp.ndarray,
     scalar_exponent: jnp.ndarray,
+    axis: Optional[int | Sequence[int]] = None,
 ) -> jnp.ndarray:
     """Compute a scalar loss from a array based on an orthotope transmission window.
 
@@ -33,9 +36,11 @@ def orthotope_smooth_transmission_loss(
         transmission_exponent: Exponent applied to the transmission and window
             bounds prior to scalarization.
         scalar_exponent: Exponent applied to the final scalar loss.
+        axis: The axes for which scalarization is sought. Default is `None`, which
+            means that a scalar is returned.
 
     Returns:
-        The scalar loss value.
+        The loss value.
     """
     # Compute the signed psuedodistance. This is equal to the signed distance to the
     # nearest bound, except when the bounds are the min and max physical transmission
@@ -56,7 +61,8 @@ def orthotope_smooth_transmission_loss(
         elementwise_signed_psuedodistance
     )
     loss: jnp.ndarray = (
-        jnp.linalg.norm(transformed_elementwise_signed_distance) ** scalar_exponent
+        jnp.linalg.norm(transformed_elementwise_signed_distance, axis=axis)
+        ** scalar_exponent
     )
     return loss
 

--- a/tests/challenges/ceviche/test_challenge.py
+++ b/tests/challenges/ceviche/test_challenge.py
@@ -75,7 +75,13 @@ class CevicheChallengesTest(unittest.TestCase):
 
         num_ports = len(c.component.ceviche_model.ports)
         num_wavelengths = len(c.component.ceviche_model.params.wavelengths)
-        dummy_response = jnp.zeros((num_wavelengths, 1, num_ports))
+        dummy_response = challenge.CevicheResponse(
+            s_parameters=jnp.zeros((num_wavelengths, 1, num_ports)),
+            wavelengths_nm=jnp.arange(num_wavelengths),
+            excite_port_idxs=jnp.asarray([0]),
+        )
 
-        _ = c.loss(dummy_response)
-        _ = c.distance_to_target(dummy_response)
+        loss = c.loss(dummy_response)
+        distance = c.distance_to_target(dummy_response)
+        self.assertSequenceEqual(loss.shape, ())
+        self.assertSequenceEqual(distance.shape, ())

--- a/tests/loss/test_transmission_loss.py
+++ b/tests/loss/test_transmission_loss.py
@@ -6,6 +6,9 @@ Copyright (c) 2023 The INVRS-IO authors.
 import functools
 import unittest
 
+import jax.numpy as jnp
+from parameterized import parameterized
+
 from invrs_gym.loss import transmission_loss
 
 
@@ -43,6 +46,26 @@ class OrthotopeSmoothLossTest(unittest.TestCase):
         self.assertGreater(loss_fn(0.7), loss_fn(0.8))
         self.assertGreater(loss_fn(0.8), loss_fn(0.9))
         self.assertGreater(loss_fn(0.9), loss_fn(1.0))
+
+    @parameterized.expand(
+        [
+            [(1,), None, ()],
+            [(1,), 0, ()],
+            [(6, 1, 3), None, ()],
+            [(6, 1, 3), (1, 2), (6,)],
+        ]
+    )
+    def test_loss_has_expected_shape(self, shape, axis, expected_shape):
+        transmission = jnp.arange(jnp.prod(jnp.asarray(shape))).reshape(shape)
+        loss = transmission_loss.orthotope_smooth_transmission_loss(
+            transmission,
+            window_lower_bound=jnp.zeros_like(transmission),
+            window_upper_bound=jnp.ones_like(transmission),
+            transmission_exponent=1,
+            scalar_exponent=1,
+            axis=axis,
+        )
+        self.assertSequenceEqual(loss.shape, expected_shape)
 
 
 class DistanceToWindowTest(unittest.TestCase):

--- a/tests/loss/test_transmission_loss.py
+++ b/tests/loss/test_transmission_loss.py
@@ -7,6 +7,7 @@ import functools
 import unittest
 
 import jax.numpy as jnp
+import numpy as onp
 from parameterized import parameterized
 
 from invrs_gym.loss import transmission_loss
@@ -85,3 +86,38 @@ class DistanceToWindowTest(unittest.TestCase):
         self.assertLess(loss_fn(0.6), loss_fn(0.7))
         self.assertLess(loss_fn(0.7), loss_fn(0.8))
         self.assertLess(loss_fn(0.8), loss_fn(1.0))
+
+
+class L2NormTest(unittest.TestCase):
+    def test_norm_axis_none(self):
+        a = jnp.arange(2 * 3 * 4 * 5).reshape((2, 3, 4, 5))
+        result = transmission_loss._l2_norm(a, axis=None)
+        expected = jnp.linalg.norm(result)
+        onp.testing.assert_array_equal(result, expected)
+
+    def test_norm_axis_tuple(self):
+        a = jnp.arange(2 * 3 * 4 * 5).reshape((2, 3, 4, 5))
+        result = transmission_loss._l2_norm(a, axis=(0, 2, 3))
+        expected = jnp.stack(
+            [
+                jnp.linalg.norm(a[:, 0, ...]),
+                jnp.linalg.norm(a[:, 1, ...]),
+                jnp.linalg.norm(a[:, 2, ...]),
+            ]
+        )
+        onp.testing.assert_array_equal(result, expected)
+
+    def test_norm_axis_int(self):
+        a = jnp.arange(2 * 3 * 4 * 5).reshape((6, 20))
+        result = transmission_loss._l2_norm(a, axis=1)
+        expected = jnp.stack(
+            [
+                jnp.linalg.norm(a[0, :]),
+                jnp.linalg.norm(a[1, :]),
+                jnp.linalg.norm(a[2, :]),
+                jnp.linalg.norm(a[3, :]),
+                jnp.linalg.norm(a[4, :]),
+                jnp.linalg.norm(a[5, :]),
+            ]
+        )
+        onp.testing.assert_array_equal(result, expected)


### PR DESCRIPTION
Ceviche challenges
- Computes a per-wavelength loss, and then perform mean reduction
- Update component response to include wavelengths and excite ports, addressing #9 

Diffractive splitter
- Use a ceviche-style loss