### PR TITLE
Adjust loss exponent for lbfgsb

### DIFF
--- a/src/invrs_gym/challenges/diffract/metagrating_challenge.py
+++ b/src/invrs_gym/challenges/diffract/metagrating_challenge.py
@@ -140,7 +140,7 @@ class MetagratingChallenge(base.Challenge):
         )
         window_size = 1 - self.transmission_lower_bound
         scaled_error = (self.transmission_lower_bound - efficiency) / window_size
-        return jnp.linalg.norm(nn.softplus(scaled_error))
+        return jnp.linalg.norm(nn.softplus(scaled_error) ** 2)
 
     def distance_to_target(self, response: common.GratingResponse) -> jnp.ndarray:
         """Compute distance from the component `response` to the challenge target."""

--- a/src/invrs_gym/challenges/diffract/metagrating_challenge.py
+++ b/src/invrs_gym/challenges/diffract/metagrating_challenge.py
@@ -140,7 +140,7 @@ class MetagratingChallenge(base.Challenge):
         )
         window_size = 1 - self.transmission_lower_bound
         scaled_error = (self.transmission_lower_bound - efficiency) / window_size
-        return jnp.linalg.norm(nn.softplus(scaled_error) ** 2)
+        return jnp.mean(nn.softplus(scaled_error) ** 2)
 
     def distance_to_target(self, response: common.GratingResponse) -> jnp.ndarray:
         """Compute distance from the component `response` to the challenge target."""


### PR DESCRIPTION
Previously, when the loss lacked the exponent of 2, the L-BFGS-B optimizer used in the notebook example would fail to make progress.