### PR TITLE
Adjust loss function for diffractive splitter and add test

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.3.4"
+current_version = "v0.3.5"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # invrs-gym - A collection of inverse design challenges
-`v0.3.4`
+`v0.3.5`
 
 ## Overview
 The `invrs_gym` package is an open-source gym containing a diverse set of photonic design challenges, which are relevant for a wide range of applications such as AR/VR, optical networking, LIDAR, and others.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "invrs_gym"
-version = "v0.3.4"
+version = "v0.3.5"
 description = "A collection of inverse design challenges"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/invrs_gym/__init__.py
+++ b/src/invrs_gym/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.3.4"
+__version__ = "v0.3.5"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 from invrs_gym import challenges as challenges

--- a/src/invrs_gym/challenges/diffract/metagrating_challenge.py
+++ b/src/invrs_gym/challenges/diffract/metagrating_challenge.py
@@ -132,7 +132,7 @@ class MetagratingChallenge(base.Challenge):
 
     def loss(self, response: common.GratingResponse) -> jnp.ndarray:
         """Compute a scalar loss from the component `response`."""
-        # Compute efficiency, a per-wavvelength is a per-wavelength scalar.
+        # Compute efficiency, a per-wavelength scalar.
         efficiency = _value_for_order(
             response.transmission_efficiency,
             expansion=response.expansion,

--- a/src/invrs_gym/challenges/diffract/splitter_challenge.py
+++ b/src/invrs_gym/challenges/diffract/splitter_challenge.py
@@ -35,7 +35,7 @@ UNIFORMITY_ERROR = "uniformity_error"
 UNIFORMITY_ERROR_WITHOUT_ZEROTH_ORDER = "uniformity_error_without_zeroth_order"
 
 TRANSMISSION_EXPONENT = 1.0
-SCALAR_EXPONENT = 1.0
+SCALAR_EXPONENT = 2.0
 
 density_initializer = functools.partial(
     utils.initializers.noisy_density_initializer,

--- a/tests/challenges/diffract/test_metagrating_challenge.py
+++ b/tests/challenges/diffract/test_metagrating_challenge.py
@@ -114,7 +114,7 @@ class MetagratingChallengeTest(unittest.TestCase):
         def loss_fn(params):
             response, aux = mc.component.response(params)
             return mc.loss(response), aux
-        
+
         value_and_grad_fn = jax.jit(jax.value_and_grad(loss_fn, has_aux=True))
         _, grad = value_and_grad_fn(params)
         self.assertFalse(jnp.any(jnp.isnan(grad.array)))


### PR DESCRIPTION
Change scalar exponent for diffractive splitter loss function to 2, mirroring what is done in the ceviche challenges and the metagrating challenge.

Add a test to the metagrating ensuring there is no NaN gradient for a uniform design.