### PR TITLE
Switch FMM formulation default to "jones direct fourier"

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.3.5"
+current_version = "v0.3.6"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # invrs-gym - A collection of inverse design challenges
-`v0.3.5`
+`v0.3.6`
 
 ## Overview
 The `invrs_gym` package is an open-source gym containing a diverse set of photonic design challenges, which are relevant for a wide range of applications such as AR/VR, optical networking, LIDAR, and others.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "invrs_gym"
-version = "v0.3.5"
+version = "v0.3.6"
 description = "A collection of inverse design challenges"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/invrs_gym/__init__.py
+++ b/src/invrs_gym/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.3.5"
+__version__ = "v0.3.6"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 from invrs_gym import challenges as challenges

--- a/src/invrs_gym/challenges/diffract/metagrating_challenge.py
+++ b/src/invrs_gym/challenges/diffract/metagrating_challenge.py
@@ -206,7 +206,7 @@ METAGRATING_SIM_PARAMS = common.GratingSimParams(
     grid_shape=(118, 45),
     wavelength=1.050,
     polarization=common.TM,
-    formulation=fmm.Formulation.JONES_DIRECT,
+    formulation=fmm.Formulation.JONES_DIRECT_FOURIER,
     approximate_num_terms=300,
     truncation=basis.Truncation.CIRCULAR,
 )

--- a/src/invrs_gym/challenges/diffract/splitter_challenge.py
+++ b/src/invrs_gym/challenges/diffract/splitter_challenge.py
@@ -368,7 +368,7 @@ def diffractive_splitter(
 
     Args:
         minimum_width: The minimum width target for the challenge, in pixels. The
-            physical minimum width is approximately 180 nm.
+            default value of 10 corresponds to a physical size of approximately 400 nm.
         minimum_spacing: The minimum spacing target for the challenge, in pixels.
         thickness_initializer: Callable which returns the initial thickness, given a
             key and seed thickness.

--- a/src/invrs_gym/challenges/diffract/splitter_challenge.py
+++ b/src/invrs_gym/challenges/diffract/splitter_challenge.py
@@ -328,7 +328,7 @@ DIFFRACTIVE_SPLITTER_SIM_PARAMS = common.GratingSimParams(
     grid_shape=(180, 180),
     wavelength=0.6328,
     polarization=common.TM,
-    formulation=fmm.Formulation.JONES_DIRECT,
+    formulation=fmm.Formulation.JONES_DIRECT_FOURIER,
     approximate_num_terms=800,
     truncation=basis.Truncation.CIRCULAR,
 )

--- a/src/invrs_gym/challenges/extractor/challenge.py
+++ b/src/invrs_gym/challenges/extractor/challenge.py
@@ -135,7 +135,7 @@ EXTRACTOR_SPEC = extractor_component.ExtractorSpec(
 EXTRACTOR_SIM_PARAMS = extractor_component.ExtractorSimParams(
     grid_spacing=0.01,
     wavelength=0.637,
-    formulation=fmm.Formulation.JONES_DIRECT,
+    formulation=fmm.Formulation.JONES_DIRECT_FOURIER,
     approximate_num_terms=1200,
     truncation=basis.Truncation.CIRCULAR,
 )
@@ -153,7 +153,7 @@ MINIMUM_SPACING = 5
 
 # Reference power values used to calculate the enhancement. These were computed
 # by `compute_reference_response` with 1600 terms in the Fourier expansion.
-BARE_SUBSTRATE_COLLECTED_POWER = jnp.asarray([2.554012, 2.554169, 0.134969])
+BARE_SUBSTRATE_COLLECTED_POWER = jnp.asarray([2.379232, 2.376114, 0.134813])
 BARE_SUBSTRATE_EMITTED_POWER = jnp.asarray([73.41745, 73.41583, 84.21051])
 
 # Target is to achieve flux enhancement of 50 times or greater.

--- a/src/invrs_gym/challenges/extractor/challenge.py
+++ b/src/invrs_gym/challenges/extractor/challenge.py
@@ -183,8 +183,8 @@ def photon_extractor(
     https://opg.optica.org/optica/fulltext.cfm?uri=optica-7-12-1805
 
     Args:
-        minimum_width: The minimum width target for the challenge, in pixels. The
-            physical minimum width is approximately 180 nm.
+        minimum_width: The minimum width target for the challenge, in pixels.  The
+            default value of 5 corresponds to a physical size of approximately 50 nm.
         minimum_spacing: The minimum spacing target for the challenge, in pixels.
         density_initializer: Callble which returns the initial density, given a
             key and seed density.

--- a/src/invrs_gym/challenges/sorter/polarization_challenge.py
+++ b/src/invrs_gym/challenges/sorter/polarization_challenge.py
@@ -177,8 +177,8 @@ def polarization_sorter(
     """Polarization sorter challenge.
 
     Args:
-        minimum_width: The minimum width target for the challenge, in pixels. The
-            physical minimum width is approximately 80 nm.
+        minimum_width: The minimum width target for the challenge, in pixels.  The
+            default value of 8 corresponds to a physical size of approximately 80 nm.
         minimum_spacing: The minimum spacing target for the challenge, in pixels.
         thickness_initializer: Callable which returns the initial thickness, given a
             key and seed thickness.

--- a/tests/challenges/diffract/test_reference_devices.py
+++ b/tests/challenges/diffract/test_reference_devices.py
@@ -26,8 +26,8 @@ class ReferenceMetagratingTest(unittest.TestCase):
             # device name, expected, tolerance
             ["device1.csv", 0.957, 0.01],  # Reticolo 0.957, Meep 0.955
             ["device2.csv", 0.933, 0.01],  # Reticolo 0.933, Meep 0.938
-            ["device3.csv", 0.966, 0.01],  # Reticolo 0.966, Meep 0.950
-            ["device4.csv", 0.933, 0.02],  # Reticolo 0.933, Meep 0.925
+            ["device3.csv", 0.966, 0.02],  # Reticolo 0.966, Meep 0.950
+            ["device4.csv", 0.933, 0.025],  # Reticolo 0.933, Meep 0.925
             ["device5.csv", 0.841, 0.02],  # Reticolo 0.841, Meep 0.843
         ]
     )
@@ -90,14 +90,14 @@ class ReferenceDiffractiveSplitterTest(unittest.TestCase):
                 0.014,  # average efficiency expected
                 0.030,  # average efficiency rtol
                 0.029,  # zeroth order efficiency expected
-                0.120,  # zeroth order efficiency rtol
+                0.100,  # zeroth order efficiency rtol
             ],
             [
                 "device3.csv",
                 0.738,  # total efficiency expected
                 0.010,  # total efficiency rtol
                 0.015,  # average efficiency expected
-                0.030,  # average efficiency rtol
+                0.010,  # average efficiency rtol
                 0.023,  # zeroth order efficiency expected
                 0.080,  # zeroth order efficiency rtol
             ],
@@ -132,6 +132,10 @@ class ReferenceDiffractiveSplitterTest(unittest.TestCase):
 
         response, aux = challenge.component.response(params)
         metrics = challenge.metrics(response, params, aux)
+
+        print(metrics["total_efficiency"])
+        print(metrics["average_efficiency"])
+        print(metrics["zeroth_order_efficiency"])
 
         onp.testing.assert_allclose(
             metrics["total_efficiency"],

--- a/tests/challenges/extractor/test_reference_devices.py
+++ b/tests/challenges/extractor/test_reference_devices.py
@@ -90,15 +90,15 @@ class ReferenceExtractorTest(unittest.TestCase):
 
         onp.testing.assert_allclose(flux_boost_jx, expected_flux_boost_jx, rtol=0.25)
         onp.testing.assert_allclose(flux_boost_jy, expected_flux_boost_jy, rtol=0.25)
-        onp.testing.assert_allclose(flux_boost_jz, expected_flux_boost_jz, rtol=0.48)
+        onp.testing.assert_allclose(flux_boost_jz, expected_flux_boost_jz, rtol=0.54)
 
         self.assertLess(flux_boost_jx, expected_flux_boost_jx)
         self.assertLess(flux_boost_jy, expected_flux_boost_jy)
         self.assertLess(flux_boost_jz, expected_flux_boost_jz)
 
-        onp.testing.assert_allclose(dos_boost_jx, expected_dos_boost_jx, rtol=0.10)
-        onp.testing.assert_allclose(dos_boost_jy, expected_dos_boost_jy, rtol=0.10)
-        onp.testing.assert_allclose(dos_boost_jz, expected_dos_boost_jz, rtol=0.10)
+        onp.testing.assert_allclose(dos_boost_jx, expected_dos_boost_jx, rtol=0.08)
+        onp.testing.assert_allclose(dos_boost_jy, expected_dos_boost_jy, rtol=0.08)
+        onp.testing.assert_allclose(dos_boost_jz, expected_dos_boost_jz, rtol=0.12)
 
         self.assertLess(dos_boost_jx, expected_dos_boost_jx)
         self.assertLess(dos_boost_jy, expected_dos_boost_jy)
@@ -147,11 +147,11 @@ class ReferenceExtractorTest(unittest.TestCase):
             onp.testing.assert_allclose(
                 response_1200.collected_power[:2],
                 response_1600.collected_power[:2],
-                rtol=0.08,
+                rtol=0.05,
             )
         with self.subTest("z dipole"):
             onp.testing.assert_allclose(
                 response_1200.collected_power[2],
                 response_1600.collected_power[2],
-                rtol=0.16,
+                rtol=0.14,
             )


### PR DESCRIPTION
For the FMMAX simulator, the "jones direct fourier" formulation is preferred, since it avoids some long calculation times associated with the "jones direct" formulation. (See https://github.com/facebookresearch/fmmax/pull/75). Here we switch the formulation for challenges using FMMAX, and slightly adjust tests to ensure everything passes. There are no concerning changes to any of the test tolerances.