### PR TITLE
Update distance metric for polarization sorter

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.5.0"
+current_version = "v0.6.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # invrs-gym - A collection of inverse design challenges
-`v0.5.0`
+`v0.6.0`
 
 ## Overview
 The `invrs_gym` package is an open-source gym containing a diverse set of photonic design challenges, which are relevant for a wide range of applications such as AR/VR, optical networking, LIDAR, and others.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "invrs_gym"
-version = "v0.5.0"
+version = "v0.6.0"
 description = "A collection of inverse design challenges"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/invrs_gym/__init__.py
+++ b/src/invrs_gym/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.5.0"
+__version__ = "v0.6.0"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 from invrs_gym import challenges as challenges

--- a/src/invrs_gym/challenges/sorter/polarization_challenge.py
+++ b/src/invrs_gym/challenges/sorter/polarization_challenge.py
@@ -101,17 +101,17 @@ class PolarizationSorterChallenge(base.Challenge):
 
     def distance_to_target(self, response: common.SorterResponse) -> jnp.ndarray:
         """Compute distance from the component `response` to the challenge target."""
-        min_allowed_on_target_transmission = self.efficiency_target
-        max_allowed_off_target_transmission = (
-            self.efficiency_target / self.polarization_ratio_target
-        )
-
         on_target_transmission = response.transmission[
             ..., tuple(range(4)), tuple(range(4))
         ]
         off_target_transmission = response.transmission[
             ..., tuple(range(4))[::-1], tuple(range(4))
-        ]
+        ][::-1]
+
+        min_allowed_on_target_transmission = self.efficiency_target
+        max_allowed_off_target_transmission = (
+            on_target_transmission / self.polarization_ratio_target
+        )
 
         on_target_error = min_allowed_on_target_transmission - on_target_transmission
         off_target_error = off_target_transmission - max_allowed_off_target_transmission

--- a/tests/challenges/sorter/test_polarization_challenge.py
+++ b/tests/challenges/sorter/test_polarization_challenge.py
@@ -57,24 +57,11 @@ class SorterChallengeTest(unittest.TestCase):
             polarization_ratio_target=ratio_target,
         )
 
-        dummy_ideal_response = common.SorterResponse(
-            wavelength=1.0,
-            polar_angle=0.0,
-            azimuthal_angle=0.0,
-            transmission=jnp.asarray(
-                [
-                    [0.5, 0.25, 0.25, 0.0],
-                    [0.25, 0.5, 0.0, 0.25],
-                    [0.25, 0.0, 0.5, 0.25],
-                    [0.0, 0.25, 0.25, 0.5],
-                ]
-            ),
-            reflection=jnp.asarray([0, 0, 0, 0]),
-        )
-
         t1 = efficiency_target
         t2 = efficiency_target / ratio_target
-        dummy_successful_response = common.SorterResponse(
+
+        # Successful response where the targets are exactly met.
+        dummy_successful_response_0 = common.SorterResponse(
             wavelength=1.0,
             polar_angle=0.0,
             azimuthal_angle=0.0,
@@ -88,6 +75,24 @@ class SorterChallengeTest(unittest.TestCase):
             ),
             reflection=jnp.asarray([0, 0, 0, 0]),
         )
+        # Successful response where efficiency exceeds the goal slightly,
+        # and the ratio exactly matches the target.
+        dummy_successful_response_1 = common.SorterResponse(
+            wavelength=1.0,
+            polar_angle=0.0,
+            azimuthal_angle=0.0,
+            transmission=jnp.asarray(
+                [
+                    [t1 + 0.1, 0, 0, (t1 + 0.1) / ratio_target],
+                    [0, t1, t2, 0],
+                    [0, t2, t1, 0],
+                    [t2, 0, 0, t1],
+                ]
+            ),
+            reflection=jnp.asarray([0, 0, 0, 0]),
+        )
+
+        # Unsuccessful response where efficiency is too low for one pixel.
         dummy_unsuccessful_response = common.SorterResponse(
             wavelength=1.0,
             polar_angle=0.0,
@@ -103,6 +108,6 @@ class SorterChallengeTest(unittest.TestCase):
             reflection=jnp.asarray([0, 0, 0, 0]),
         )
 
+        self.assertEqual(pc.distance_to_target(dummy_successful_response_0), 0)
+        self.assertEqual(pc.distance_to_target(dummy_successful_response_1), 0)
         self.assertGreater(pc.distance_to_target(dummy_unsuccessful_response), 0)
-        self.assertEqual(pc.distance_to_target(dummy_successful_response), 0)
-        self.assertLess(pc.distance_to_target(dummy_ideal_response), 0)

--- a/tests/challenges/sorter/test_polarization_challenge.py
+++ b/tests/challenges/sorter/test_polarization_challenge.py
@@ -7,11 +7,12 @@ import dataclasses
 import unittest
 
 import jax
+import jax.numpy as jnp
 import optax
 from fmmax import fmm
 from parameterized import parameterized
 
-from invrs_gym.challenges.sorter import polarization_challenge
+from invrs_gym.challenges.sorter import common, polarization_challenge
 
 LIGHTWEIGHT_SIM_PARAMS = dataclasses.replace(
     polarization_challenge.POLARIZATION_SORTER_SIM_PARAMS,
@@ -20,7 +21,7 @@ LIGHTWEIGHT_SIM_PARAMS = dataclasses.replace(
 )
 
 
-class SplitterChallengeTest(unittest.TestCase):
+class SorterChallengeTest(unittest.TestCase):
     @parameterized.expand([[lambda fn: fn], [jax.jit]])
     def test_optimize(self, step_fn_decorator):
         pc = polarization_challenge.polarization_sorter(
@@ -47,3 +48,61 @@ class SplitterChallengeTest(unittest.TestCase):
             return params, state, metrics
 
         step_fn(params, state)
+
+    @parameterized.expand([[0.4, 10], [0.36, 6]])
+    def test_distance(self, efficiency_target, ratio_target):
+        pc = polarization_challenge.polarization_sorter(
+            sim_params=LIGHTWEIGHT_SIM_PARAMS,
+            efficiency_target=efficiency_target,
+            polarization_ratio_target=ratio_target,
+        )
+
+        dummy_ideal_response = common.SorterResponse(
+            wavelength=1.0,
+            polar_angle=0.0,
+            azimuthal_angle=0.0,
+            transmission=jnp.asarray(
+                [
+                    [0.5, 0.25, 0.25, 0.0],
+                    [0.25, 0.5, 0.0, 0.25],
+                    [0.25, 0.0, 0.5, 0.25],
+                    [0.0, 0.25, 0.25, 0.5],
+                ]
+            ),
+            reflection=jnp.asarray([0, 0, 0, 0]),
+        )
+
+        t1 = efficiency_target
+        t2 = efficiency_target / ratio_target
+        dummy_successful_response = common.SorterResponse(
+            wavelength=1.0,
+            polar_angle=0.0,
+            azimuthal_angle=0.0,
+            transmission=jnp.asarray(
+                [
+                    [t1, 0, 0, t2],
+                    [0, t1, t2, 0],
+                    [0, t2, t1, 0],
+                    [t2, 0, 0, t1],
+                ]
+            ),
+            reflection=jnp.asarray([0, 0, 0, 0]),
+        )
+        dummy_unsuccessful_response = common.SorterResponse(
+            wavelength=1.0,
+            polar_angle=0.0,
+            azimuthal_angle=0.0,
+            transmission=jnp.asarray(
+                [
+                    [t1 - 0.001, 0, 0, t2],
+                    [0, t1, t2, 0],
+                    [0, t2, t1, 0],
+                    [t2 + 0.001, 0, 0, t1],
+                ]
+            ),
+            reflection=jnp.asarray([0, 0, 0, 0]),
+        )
+
+        self.assertGreater(pc.distance_to_target(dummy_unsuccessful_response), 0)
+        self.assertEqual(pc.distance_to_target(dummy_successful_response), 0)
+        self.assertLess(pc.distance_to_target(dummy_ideal_response), 0)


### PR DESCRIPTION
This PR updates the sorter distance metric to be the maximum violation of power; i.e. insufficient power into a target pixel (given some desired efficiency) or excess power into an off-target pixel (given the efficiency and desired polarization ratio).