### PR TITLE
Add flexibility to `diffract` challenges

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.6.1"
+current_version = "v0.7.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # invrs-gym - A collection of inverse design challenges
-`v0.6.1`
+`v0.7.0`
 
 ## Overview
 The `invrs_gym` package is an open-source gym containing a diverse set of photonic design challenges, which are relevant for a wide range of applications such as AR/VR, optical networking, LIDAR, and others.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "invrs_gym"
-version = "v0.6.1"
+version = "v0.7.0"
 description = "A collection of inverse design challenges"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/invrs_gym/__init__.py
+++ b/src/invrs_gym/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.6.1"
+__version__ = "v0.7.0"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 from invrs_gym import challenges as challenges

--- a/src/invrs_gym/challenges/diffract/common.py
+++ b/src/invrs_gym/challenges/diffract/common.py
@@ -33,6 +33,7 @@ class GratingSpec:
         thickness_grating: Thickness of the grating layer.
         period_x: The size of the unit cell along the x direction.
         period_y: The size of the unit cell along the y direction.
+        grid_spacing: The spacing of the grid on which grating permittivity is defined.
     """
 
     permittivity_ambient: complex
@@ -45,13 +46,22 @@ class GratingSpec:
     period_x: float
     period_y: float
 
+    grid_spacing: float
+
+    @property
+    def grid_shape(self) -> Tuple[int, int]:
+        """Return the shape of the grid implied by `grid_spacing`."""
+        return (
+            int(jnp.ceil(self.period_x / self.grid_spacing)),
+            int(jnp.ceil(self.period_y / self.grid_spacing)),
+        )
+
 
 @dataclasses.dataclass
 class GratingSimParams:
     """Parameters that configure the simulation of a grating.
 
     Attributes:
-        grid_spacing: The spacing of the grid on which grating permittivity is defined.
         wavelength: The wavelength of the excitation.
         polar_angle: The polar angle of the excitation.
         azimuthal_angle: The azimuthal angle of the excitation.
@@ -60,7 +70,6 @@ class GratingSimParams:
         truncation: Determines how the Fourier basis is truncated.
     """
 
-    grid_spacing: float
     wavelength: float | jnp.ndarray
     polar_angle: float | jnp.ndarray
     azimuthal_angle: float | jnp.ndarray
@@ -109,16 +118,6 @@ tree_util.register_pytree_node(
     ),
     lambda _, children: GratingResponse(*children),
 )
-
-
-def grid_shape(
-    period_x: float, period_y: float, grid_spacing: float
-) -> Tuple[int, int]:
-    """Return the grid shape for the given unit cell parameters."""
-    return (
-        int(jnp.ceil(period_x / grid_spacing)),
-        int(jnp.ceil(period_y / grid_spacing)),
-    )
 
 
 def seed_density(grid_shape: Tuple[int, int], **kwargs: Any) -> types.Density2DArray:

--- a/src/invrs_gym/challenges/diffract/metagrating_challenge.py
+++ b/src/invrs_gym/challenges/diffract/metagrating_challenge.py
@@ -51,11 +51,7 @@ class MetagratingComponent(base.Component):
         self.spec = spec
         self.sim_params = sim_params
         self.seed_density = common.seed_density(
-            grid_shape=common.grid_shape(
-                period_x=spec.period_x,
-                period_y=spec.period_y,
-                grid_spacing=sim_params.grid_spacing,
-            ),
+            grid_shape=self.spec.grid_shape,
             **seed_density_kwargs,
         )
         self.density_initializer = density_initializer
@@ -212,10 +208,10 @@ METAGRATING_SPEC = common.GratingSpec(
     thickness_grating=0.325,
     period_x=float(1.050 / jnp.sin(jnp.deg2rad(50.0))),
     period_y=0.525,
+    grid_spacing=0.0117,  # Yields a grid shape of `(118, 45)`.
 )
 
 METAGRATING_SIM_PARAMS = common.GratingSimParams(
-    grid_spacing=0.0117,  # Yields a grid shape of `(118, 45)`.
     wavelength=1.050,
     polar_angle=0.0,
     azimuthal_angle=0.0,

--- a/src/invrs_gym/challenges/diffract/splitter_challenge.py
+++ b/src/invrs_gym/challenges/diffract/splitter_challenge.py
@@ -75,11 +75,7 @@ class DiffractiveSplitterComponent(base.Component):
         self.density_initializer = density_initializer
 
         self.seed_density = common.seed_density(
-            grid_shape=common.grid_shape(
-                period_x=spec.period_x,
-                period_y=spec.period_y,
-                grid_spacing=sim_params.grid_spacing,
-            ),
+            grid_shape=self.spec.grid_shape,
             **seed_density_kwargs,
         )
 
@@ -334,10 +330,10 @@ DIFFRACTIVE_SPLITTER_SPEC = common.GratingSpec(
     thickness_grating=types.BoundedArray(array=0.692, lower_bound=0.5, upper_bound=1.5),
     period_x=7.2,
     period_y=7.2,
+    grid_spacing=0.04,  # Yields a grid shape of `(180, 180)`.
 )
 
 DIFFRACTIVE_SPLITTER_SIM_PARAMS = common.GratingSimParams(
-    grid_spacing=0.04,  # Yields a grid shape of `(180, 180)`.
     wavelength=0.6328,
     polar_angle=0.0,
     azimuthal_angle=0.0,

--- a/src/invrs_gym/challenges/extractor/challenge.py
+++ b/src/invrs_gym/challenges/extractor/challenge.py
@@ -137,10 +137,10 @@ EXTRACTOR_SPEC = extractor_component.ExtractorSpec(
     offset_monitor_source=0.025,
     offset_monitor_ambient=0.4,
     width_monitor_ambient=1.5,
+    grid_spacing=0.005,
 )
 
 EXTRACTOR_SIM_PARAMS = extractor_component.ExtractorSimParams(
-    grid_spacing=0.005,
     wavelength=0.637,
     formulation=fmm.Formulation.JONES_DIRECT_FOURIER,
     approximate_num_terms=1200,

--- a/src/invrs_gym/challenges/sorter/polarization_challenge.py
+++ b/src/invrs_gym/challenges/sorter/polarization_challenge.py
@@ -202,11 +202,11 @@ POLARIZATION_SORTER_SPEC = common.SorterSpec(
         types.BoundedArray(1.0, lower_bound=0.8, upper_bound=1.2),
     ),
     pitch=2.0,
+    grid_spacing=0.01,
     offset_monitor_substrate=0.1,
 )
 
 POLARIZATION_SORTER_SIM_PARAMS = common.SorterSimParams(
-    grid_spacing=0.01,
     wavelength=0.55,
     polar_angle=0.0,
     azimuthal_angle=0.0,

--- a/tests/challenges/diffract/test_common.py
+++ b/tests/challenges/diffract/test_common.py
@@ -17,6 +17,8 @@ class GatingResponseTest(unittest.TestCase):
     def test_flatten_unflatten(self):
         original = common.GratingResponse(
             wavelength=jnp.arange(3),
+            polar_angle=jnp.arange(4),
+            azimuthal_angle=jnp.arange(5),
             transmission_efficiency=jnp.arange(4),
             reflection_efficiency=jnp.arange(5),
             expansion=basis.Expansion(
@@ -26,6 +28,10 @@ class GatingResponseTest(unittest.TestCase):
         leaves, treedef = tree_util.tree_flatten(original)
         restored = tree_util.tree_unflatten(treedef, leaves)
         onp.testing.assert_array_equal(restored.wavelength, original.wavelength)
+        onp.testing.assert_array_equal(restored.polar_angle, original.polar_angle)
+        onp.testing.assert_array_equal(
+            restored.azimuthal_angle, original.azimuthal_angle
+        )
         onp.testing.assert_array_equal(
             restored.transmission_efficiency, original.transmission_efficiency
         )

--- a/tests/challenges/diffract/test_metagrating_challenge.py
+++ b/tests/challenges/diffract/test_metagrating_challenge.py
@@ -50,6 +50,15 @@ class MetagratingComponentTest(unittest.TestCase):
             (2, mc.expansion.num_terms, 1),
         )
 
+    def test_default_grid_shape(self):
+        mc = metagrating_challenge.MetagratingComponent(
+            spec=metagrating_challenge.METAGRATING_SPEC,
+            sim_params=LIGHTWEIGHT_SIM_PARAMS,
+            density_initializer=lambda _, seed_density: seed_density,
+        )
+        params = mc.init(jax.random.PRNGKey(0))
+        self.assertSequenceEqual(params.shape, (118, 45))
+
 
 class MetagratingChallengeTest(unittest.TestCase):
     @parameterized.expand([[lambda fn: fn], [jax.jit]])

--- a/tests/challenges/diffract/test_reference_devices.py
+++ b/tests/challenges/diffract/test_reference_devices.py
@@ -42,14 +42,9 @@ class ReferenceMetagratingTest(unittest.TestCase):
         if density_array.ndim == 1:
             density_array = jnp.broadcast_to(density_array[:, jnp.newaxis], (119, 45))
 
-        sim_params = dataclasses.replace(
-            metagrating_challenge.METAGRATING_SIM_PARAMS,
-            grid_shape=density_array.shape,
-        )
-
         mc = metagrating_challenge.MetagratingComponent(
             spec=metagrating_challenge.METAGRATING_SPEC,
-            sim_params=sim_params,
+            sim_params=metagrating_challenge.METAGRATING_SIM_PARAMS,
             density_initializer=lambda _, seed_density: seed_density,
         )
 

--- a/tests/challenges/diffract/test_splitter_challenge.py
+++ b/tests/challenges/diffract/test_splitter_challenge.py
@@ -51,6 +51,16 @@ class SplitterComponentTest(unittest.TestCase):
             (2, mc.expansion.num_terms, 1),
         )
 
+    def test_default_grid_shape(self):
+        mc = splitter_challenge.DiffractiveSplitterComponent(
+            spec=splitter_challenge.DIFFRACTIVE_SPLITTER_SPEC,
+            sim_params=LIGHTWEIGHT_SIM_PARAMS,
+            thickness_initializer=lambda _, x: x,
+            density_initializer=lambda _, seed_density: seed_density,
+        )
+        params = mc.init(jax.random.PRNGKey(0))
+        self.assertSequenceEqual(params["density"].shape, (180, 180))
+
 
 class SplitterChallengeTest(unittest.TestCase):
     @parameterized.expand([[lambda fn: fn], [jax.jit]])

--- a/tests/challenges/extractor/test_challenge.py
+++ b/tests/challenges/extractor/test_challenge.py
@@ -71,7 +71,7 @@ class ExtractorChallengeTest(unittest.TestCase):
         )
         self.assertEqual(params.minimum_width, min_width)
         self.assertEqual(params.minimum_spacing, min_spacing)
-        pad = (ec.component.grid_shape[0] - 300) // 2
+        pad = (ec.component.spec.grid_shape[0] - 300) // 2
         expected_fixed_void = onp.pad(
             onp.zeros((300, 300), bool),
             ((pad, pad), (pad, pad)),

--- a/tests/challenges/extractor/test_component.py
+++ b/tests/challenges/extractor/test_component.py
@@ -28,7 +28,7 @@ class ExtractorComponentTest(unittest.TestCase):
         self.assertSequenceEqual(params.periodic, (False, False))
         onp.testing.assert_array_equal(params.fixed_solid, False)
 
-        pad = (ec.grid_shape[0] - 300) // 2
+        pad = (ec.spec.grid_shape[0] - 300) // 2
         expected_fixed_void = onp.pad(
             onp.zeros((300, 300), bool),
             ((pad, pad), (pad, pad)),

--- a/tests/challenges/extractor/test_reference_devices.py
+++ b/tests/challenges/extractor/test_reference_devices.py
@@ -37,7 +37,7 @@ class ReferenceExtractorTest(unittest.TestCase):
         # design is not included in the csv; pad to the correct shape.
         density_array = onp.genfromtxt(DESIGNS_DIR / "device1.csv", delimiter=",")
         assert density_array.shape == (300, 300)
-        assert 1000 * spec.pitch / pec.component.grid_shape[0] == 5
+        assert 1000 * spec.pitch / pec.component.spec.grid_shape[0] == 5
         pad = (params.shape[0] - density_array.shape[0]) // 2
         density_array = onp.pad(density_array, ((pad, pad), (pad, pad)))
         assert density_array.shape == params.shape

--- a/tests/challenges/sorter/test_common.py
+++ b/tests/challenges/sorter/test_common.py
@@ -28,11 +28,11 @@ EXAMPLE_SPEC = common.SorterSpec(
     ),
     thickness_spacer=(types.BoundedArray(1.0, lower_bound=0.5, upper_bound=1.5),),
     pitch=2.0,
+    grid_spacing=0.01,
     offset_monitor_substrate=0.05,
 )
 
 EXAMPLE_SIM_PARAMS = common.SorterSimParams(
-    grid_spacing=0.01,
     wavelength=0.55,
     polar_angle=0.0,
     azimuthal_angle=0.0,


### PR DESCRIPTION
- Adds flexibility to the diffract challenges, allowing incident angles can be specified.
- Some cleanup of `diffract.common`, renaming variables to be consistent throughout
- In all the fmmax-backed challenges, make the grid spacing a property of the `spec` rather than the `sim_params`.