### PR TITLE
Generalize diffract components and move to common module

### DIFF
--- a/src/invrs_gym/challenges/base.py
+++ b/src/invrs_gym/challenges/base.py
@@ -16,6 +16,7 @@ from invrs_gym.utils import metrics
 AuxDict = Dict[str, Any]
 PyTree = Any
 DensityInitializer = Callable[[jax.Array, types.Density2DArray], types.Density2DArray]
+ThicknessInitializer = Callable[[jax.Array, types.BoundedArray], types.BoundedArray]
 
 BINARIZATION_DEGREE = "binarization_degree"
 


### PR DESCRIPTION
Move the `MetagratingComponent` and `DiffractiveSplitterComponent` into the `challenges.diffract.common` module, renaming these to `SimpleGratingComponent` and `GratingWithOptimizableThicknessComponent`, so they can be used by other challenges.

Also slightly adjust tolerances in reference diffractive splitter simulations. Platform differences or an update to jax caused this test to fail on my machine (even on the main branch).