### PR TITLE
Make use of new method for computing scattering matrices

### DIFF
--- a/docs/notebooks/metalens_challenge.ipynb
+++ b/docs/notebooks/metalens_challenge.ipynb
@@ -151,7 +151,7 @@
     "\n",
     "ex, ey, ez = aux[\"efield\"]\n",
     "x, _, z = aux[\"field_coordinates\"]\n",
-    "xplot, zplot = onp.meshgrid(x[:, 0], z, indexing=\"ij\")\n",
+    "xplot, zplot = onp.meshgrid(x[0, :, 0], z, indexing=\"ij\")\n",
     "\n",
     "abs_field = onp.sqrt(onp.abs(ex) ** 2 + onp.abs(ey) ** 2 + onp.abs(ez) ** 2)\n",
     "\n",

--- a/src/invrs_gym/challenges/metalens/challenge.py
+++ b/src/invrs_gym/challenges/metalens/challenge.py
@@ -67,7 +67,7 @@ class MetalensChallenge(base.Challenge):
         else:
             enhancement = response.enhancement_ey
 
-        return soft_amax(-enhancement, scale=5.0)
+        return soft_amax(-enhancement, scale=10.0)
 
     def distance_to_target(
         self, response: metalens_component.MetalensResponse

--- a/src/invrs_gym/challenges/metalens/component.py
+++ b/src/invrs_gym/challenges/metalens/component.py
@@ -393,9 +393,11 @@ def simulate_metalens(
         )
         s_matrix = s_matrices_interior[-1][0]
     else:
-        solve_results_metalens = eigensolve_fn(
+        solve_results_metalens_batch = eigensolve_fn(
             permittivity=jnp.asarray(metalens_permittivities)[:, jnp.newaxis, :, :]
         )
+        # Merge with the ambient and substrate solve results to get the solve results
+        # for the full stack, needed by `stack_s_matrix_scan`.
         stack_layer_solve_results = tree_util.tree_map(
             lambda a, b, c: jnp.concatenate(
                 [
@@ -405,7 +407,7 @@ def simulate_metalens(
                 ]
             ),
             solve_result_ambient,
-            solve_results_metalens,
+            solve_results_metalens_batch,
             solve_result_substrate,
         )
         s_matrix = scattering.stack_s_matrix_scan(


### PR DESCRIPTION
This PR goes with https://github.com/facebookresearch/fmmax/pull/103, and makes use the s-matrix generation using scan. This eliminates previously observed slowness for the metalens challenge when running on GPU.

We also tweak the loss function of the metalens challenge, using a function that resembles a soft minimax objective.