### PR TITLE
Improve eval metric for diffractive splitter

### DIFF
--- a/src/invrs_gym/challenges/diffract/splitter_challenge.py
+++ b/src/invrs_gym/challenges/diffract/splitter_challenge.py
@@ -113,7 +113,7 @@ class DiffractiveSplitterChallenge(base.Challenge):
         The eval metric rewards high total efficiency and minimum nonuniformity.
         It is computed by,
 
-            eval_metric = 0.5 * total_efficiency + 0.5 * (1 - uniformity_error)
+            eval_metric = total_efficiency * (1 - uniformity_error)
 
         In cases where multiple wavelengths or incident angles are considered, the
         eval metric is the minimum across all excitation conditions.
@@ -146,7 +146,7 @@ class DiffractiveSplitterChallenge(base.Challenge):
             + jnp.amin(transmission, axis=(-2, -1))
         )
 
-        return jnp.amin(0.5 * total_efficiency + 0.5 * (1 - uniformity_error))
+        return jnp.amin(total_efficiency * (1 - uniformity_error))
 
     def metrics(
         self,


### PR DESCRIPTION
The previous eval metric was the sum of

0.5 * (efficiency + (1 - uniformity_error))

which gives a relatively high score to a no-metasurface solution, which simply propagates through the normally-incident plane wave without diffracting into any of the other target orders. This PR switches it to

efficiency * (1 - uniformity_error)