### PR TITLE
Add run_first script

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,9 @@ jobs:
             pip install ".[tests,dev,docs]"
 
       - name: docs
-        run: jb build docs
+        run: |
+          python docs/run_first.py
+          jb build docs
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/docs/run_first.py
+++ b/docs/run_first.py
@@ -1,0 +1,8 @@
+# Some dependencies of the gym print the first time they are imported, e.g. the
+# `refractiveindex` project. In the docs github workflow, running this script
+# before any of the notebooks avoids these print statements showing up in the
+# output of the notebooks.
+from invrs_gym import challenges as challenges
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
The run_first script is run in the docs workflow. Its only purpose is to trigger the initialization of the refractiveindex.info database; this contains print statements, which would otherwise show up in the docs notebooks output.