### PR TITLE
Updated meta-atom library challenge

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v1.2.0"
+current_version = "v1.3.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # invrs-gym
-`v1.2.0`
+`v1.3.0`
 
 ## Overview
 The `invrs_gym` package is an open-source gym containing a diverse set of photonic design challenges, which are relevant for a wide range of applications such as AR/VR, optical networking, LIDAR, and others.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "invrs_gym"
-version = "v1.2.0"
+version = "v1.3.0"
 description = "A collection of inverse design challenges"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/invrs_gym/__init__.py
+++ b/src/invrs_gym/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v1.2.0"
+__version__ = "v1.3.0"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 from invrs_gym import challenges as challenges

--- a/src/invrs_gym/challenges/library/challenge.py
+++ b/src/invrs_gym/challenges/library/challenge.py
@@ -419,6 +419,12 @@ def meta_atom_library(
     reaching broadband 90% relative diffraction efficiency" by Chen et al.
     https://www.nature.com/articles/s41467-023-38185-2
 
+    In the library design challenge, all possible rotations of the individual meta-
+    atoms are considered. The optimal rotation (i.e. that which yield the highest
+    wavelength-averaged relative efficiency) is used to compute evaluation metrics
+    and loss. The optimal rotations can be found and applied using the
+    `optimal_rotation` and `rotate_params` functions in this module.
+
     Args:
         minimum_width: The minimum width target for the challenge, in pixels.
         minimum_spacing: The minimum spacing target for the challenge, in pixels.

--- a/tests/challenges/library/test_challenge.py
+++ b/tests/challenges/library/test_challenge.py
@@ -95,9 +95,7 @@ class MetagratingChallengeTest(unittest.TestCase):
         self.assertEqual(density.lower_bound, 0.0)
         self.assertEqual(density.upper_bound, 1.0)
         self.assertSequenceEqual(density.periodic, (False, False))
-        self.assertSequenceEqual(
-            density.symmetries, ("reflection_n_s", "reflection_e_w")
-        )
+        self.assertSequenceEqual(density.symmetries, ("reflection_n_s",))
         self.assertEqual(density.minimum_width, min_width)
         self.assertEqual(density.minimum_spacing, min_spacing)
         self.assertIsNone(density.fixed_solid)

--- a/tests/challenges/library/test_rotation.py
+++ b/tests/challenges/library/test_rotation.py
@@ -1,0 +1,103 @@
+"""Tests for the meta-atom library challenge related to nanostructure rotation.
+
+Copyright (c) 2024 The INVRS-IO authors.
+"""
+
+import copy
+import pathlib
+import unittest
+
+import jax.numpy as jnp
+import numpy as onp
+from totypes import json_utils
+
+from invrs_gym.challenges.library import challenge as library_challenge
+
+REPO_PATH = pathlib.Path(__file__).resolve().parent.parent.parent.parent
+DESIGNS_DIR = REPO_PATH / "reference_designs/meta_atom_library"
+
+
+class RotationTest(unittest.TestCase):
+    def test_rotated_response_matches_expected(self):
+        challenge = library_challenge.meta_atom_library()
+
+        # Compute response of rotated nanostructures by modifying the response of
+        # nanostructures in their original orientation.
+        with open(DESIGNS_DIR / "library1.json") as f:
+            serialized = f.read()
+        params = json_utils.pytree_from_json(serialized)
+        response, _ = challenge.component.response(params)
+        rotated_response = library_challenge._rotate_response(
+            response, jnp.ones((8,), dtype=bool)
+        )
+
+        # Compute response of rotated nanostructures by directly simulating the
+        # rotated nanostructures.
+        rotated_params = copy.deepcopy(params)
+        rotated_params["density"].array = jnp.stack(
+            [jnp.rot90(x) for x in rotated_params["density"].array],
+            axis=0,
+        )
+        expected_rotated_response, _ = challenge.component.response(rotated_params)
+
+        with self.subTest("transmission_rhcp"):
+            onp.testing.assert_allclose(
+                rotated_response.transmission_rhcp,
+                expected_rotated_response.transmission_rhcp,
+                rtol=0.01,
+                atol=0.001,
+            )
+        with self.subTest("transmission_lhcp"):
+            onp.testing.assert_allclose(
+                rotated_response.transmission_lhcp,
+                expected_rotated_response.transmission_lhcp,
+                rtol=0.01,
+                atol=0.001,
+            )
+        with self.subTest("reflection_rhcp"):
+            onp.testing.assert_allclose(
+                rotated_response.reflection_rhcp,
+                expected_rotated_response.reflection_rhcp,
+                rtol=0.01,
+                atol=0.001,
+            )
+        with self.subTest("reflection_lhcp"):
+            onp.testing.assert_allclose(
+                rotated_response.reflection_lhcp,
+                expected_rotated_response.reflection_lhcp,
+                rtol=0.01,
+                atol=0.001,
+            )
+
+    def test_optimal_rotation(self):
+        challenge = library_challenge.meta_atom_library()
+
+        # Compute response of rotated nanostructures by modifying the response of
+        # nanostructures in their original orientation.
+        with open(DESIGNS_DIR / "library1.json") as f:
+            serialized = f.read()
+        params = json_utils.pytree_from_json(serialized)
+        response, _ = challenge.component.response(params)
+
+        optimal_rotation_idx = library_challenge.optimal_rotation(
+            response, challenge.component.spec
+        )
+        self.assertEqual(optimal_rotation_idx, 0)
+
+        # Apply a random rotation, and check that the optimal rotation is the one
+        # that undoes the random rotation.
+        is_rotated = jnp.asarray([0, 1, 0, 1, 1, 0, 1, 1], dtype=bool)
+        rotated_response = library_challenge._rotate_response(response, is_rotated)
+
+        optimal_rotation_idx_for_rotated_response = library_challenge.optimal_rotation(
+            rotated_response, challenge.component.spec
+        )
+
+        expected_rotation_idx = library_challenge.rotation_idx_from_is_rotated(
+            ~is_rotated
+        )
+        self.assertNotEqual(optimal_rotation_idx_for_rotated_response, 0.0)
+        self.assertEqual(
+            optimal_rotation_idx_for_rotated_response,
+            expected_rotation_idx,
+        )


### PR DESCRIPTION
- modify symmetry so that only uniaxial mirror symmetry is required. This matches the requirement from [Chen et al.](https://www.nature.com/articles/s41467-023-38185-2#MOESM1)
- consider rotated meta-atoms in the evaluation of `loss`, `eval_metric`, and `metrics`. The response corresponding to "optimally rotated" meta-atoms is used in the calculation of these quantities, where the optimal rotation is the rotation yielding maximum average relative efficiency.