### PR TITLE
pin dependencies to earlier version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "agjax",
     "ceviche_challenges",
     "fmmax <= 0.11.0",
-    "jax <= 0.4.38",
+    "jax <= 0.4.35",
     "jaxlib",
     "numpy",
     "refractiveindex",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
 dependencies = [
     "agjax",
     "ceviche_challenges",
-    "fmmax",
+    "fmmax <= 0.11.0",
     "jax <= 0.4.38",
     "jaxlib",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "agjax",
     "ceviche_challenges",
     "fmmax <= 0.11.0",
-    "jax <= 0.4.35",
+    "jax <= 0.4.36",
     "jaxlib",
     "numpy",
     "refractiveindex",


### PR DESCRIPTION
Newer versions of fmmax appear to cause a breakage